### PR TITLE
Add sendable conformance when available

### DIFF
--- a/Sources/SemanticVersion/SemanticVersion.swift
+++ b/Sources/SemanticVersion/SemanticVersion.swift
@@ -96,6 +96,10 @@ extension SemanticVersion {
     public var isInitialRelease: Bool { return self == .init(0, 0, 0) }
 }
 
+#if swift(>=5.5)
+extension SemanticVersion: Sendable {}
+#endif
+
 
 // Source: https://regex101.com/r/Ly7O1x/3/
 // Linked from https://semver.org


### PR DESCRIPTION
Currently, using `SemanticVersion` in a `Sendable` context emits a compiler warning (and I assume an error in the future). Importing as `@preconcurrency` or adding an `@unchecked` conformance will resolve it but it would be preferable for that to be unnecessary.

This PR resolves that warning and the need to add conformance in downstream projects.
