### PR TITLE
Updates to CI and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,24 @@ jobs:
         os: [macos-12, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - run: swift build --disable-automatic-resolution -c release
+        - uses: actions/checkout@v4
+        - uses: fwal/setup-swift@v2
+        - name: Echo Swift version
+          run: swift --version
+        - name: Check a Release build
+          run: swift build --disable-automatic-resolution -c release
 
   run-tests:
     strategy:
       matrix:
-        swift-version: [5.6, 5.7, 5.8, 5.9]
+        swift-version: [5.6, 5.7, 5.8, 5.9, 5.10]
     runs-on: ubuntu-20.04
     steps:
-      - uses: fwal/setup-swift@v1
+      - uses: actions/checkout@v4
+      - uses: fwal/setup-swift@v2
         with:
           swift-version: ${{ matrix.swift-version }}
-      - uses: actions/checkout@v2
-      - run: swift test
+      - name: Echo Swift version
+        run: swift --version
+      - name: Test
+        run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        swift-version: [5.6, 5.7, 5.8, 5.9, 5.10]
+        # We don't need anything specific in 5.10.1, but 5.10 collapses to 5.1 when `swift-setup` runs.
+        swift-version: [5.6, 5.7, 5.8, 5.9, 5.10.1]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        # We don't need anything specific in 5.10.1, but 5.10 collapses to 5.1 when `swift-setup` runs.
         swift-version: ['5.6', '5.7', '5.8', '5.9', '5.10']
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         # We don't need anything specific in 5.10.1, but 5.10 collapses to 5.1 when `swift-setup` runs.
-        swift-version: [5.6, 5.7, 5.8, 5.9, 5.10.1]
+        swift-version: ['5.6', '5.7', '5.8', '5.9', '5.10']
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Just a couple of updates after doing the CI for Plot. We were out of date with a few of the GH Actions scripts so I updated those and also set up dependabot monitoring for them.

Also, our release build on macOS was running with Swift 5.7 and the Linux one was running with 5.10. They now both run with 5.10. Also started echoing the Swift version as part of the action and added a couple more labels to make the CI result more readable.

We may want to remove 5.6 and 5.7 testing at some point but I left them for now.