### PR TITLE
Avoid resource bundle accessor generation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,13 @@ let package = Package(
     targets: [
         .target(name: "SemanticVersion",
                 dependencies: [],
-                resources: [.process("Documentation.docc")]),
+                resources: resources),
         .testTarget(name: "SemanticVersionTests", dependencies: ["SemanticVersion"]),
     ]
 )
+
+#if canImport(Foundation)
+let resources: [Resource] = [.process("Documentation.docc")]
+#else
+let resources: [Resource] = []
+#endif


### PR DESCRIPTION
Declaring resources in `Package.swift` triggers bundle accessor code generation, which will pull in Foundation:

```
/host/.build/wasm32-unknown-wasi/debug/SemanticVersion.build/DerivedSources/resource_bundle_accessor.swift:1:8: error: no such module 'Foundation'
 1 | import Foundation
   |        `- error: no such module 'Foundation'
```