### PR TITLE
Revert "Fix wasm 6.2 build"

### DIFF
--- a/Sources/SemanticVersion/SemanticVersion+LosslessStringConvertible.swift
+++ b/Sources/SemanticVersion/SemanticVersion+LosslessStringConvertible.swift
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if os(wasm) && swift(<6.3)
-import Foundation
-#endif
-
 
 extension SemanticVersion: LosslessStringConvertible {
 


### PR DESCRIPTION
This reverts commit dbc46a7e84af63f440ffc26b0decceb1874b0862.

The issue was that the build randomly selected the embedded SDK, which is also present.

```
# swift sdk list
swift-6.3-RELEASE_wasm
swift-6.3-RELEASE_wasm-embedded
```

```
root@orbstack:/host/SemanticVersion# swift build --swift-sdk wasm32-unknown-wasip1
warning: multiple Swift SDKs match target triple `wasm32-unknown-wasip1` and host triple x86_64-unknown-linux-gnu, selected one at /root/.swiftpm/swift-sdks/swift-6.3-RELEASE_wasm.artifactbundle/swift-6.3-RELEASE_wasm/wasm32-unknown-wasip1/embedded-swift-sdk.json
[1/1] Planning build
Building for debugging...
error: emit-module command failed with exit code 1 (use -v to see invocation)
/host/SemanticVersion/Sources/SemanticVersion/SemanticVersion+LosslessStringConvertible.swift:46:19: error: missing 'Regex' declaration, probably because the '_StringProcessing' module was not imported properly
44 | // Source: https://regex101.com/r/Ly7O1x/3/
45 | // Linked from https://semver.org
46 | let semVerRegex = #/
   |                   `- error: missing 'Regex' declaration, probably because the '_StringProcessing' module was not imported properly
47 |     ^
48 |     v?                              # SPI extension: allow leading 'v'

/host/SemanticVersion/Sources/SemanticVersion/SemanticVersion+LosslessStringConvertible.swift:25:34: error: value of type 'String' has no member 'wholeMatch'
23 |     /// - Parameter string: Version string.
24 |     public init?(_ string: String) {
25 |         guard let match = string.wholeMatch(of: semVerRegex) else { return nil }
   |                                  `- error: value of type 'String' has no member 'wholeMatch'
26 |         guard
27 |             let major = Int(match.major),
/host/SemanticVersion/Sources/SemanticVersion/SemanticVersion+LosslessStringConvertible.swift:46:19: error: missing 'Regex' declaration, probably because the '_StringProcessing' module was not imported properly
44 | // Source: https://regex101.com/r/Ly7O1x/3/
45 | // Linked from https://semver.org
46 | let semVerRegex = #/
   |                   `- error: missing 'Regex' declaration, probably because the '_StringProcessing' module was not imported properly
47 |     ^
48 |     v?                              # SPI extension: allow leading 'v'

/host/SemanticVersion/Sources/SemanticVersion/SemanticVersion+LosslessStringConvertible.swift:25:34: error: value of type 'String' has no member 'wholeMatch'
23 |     /// - Parameter string: Version string.
24 |     public init?(_ string: String) {
25 |         guard let match = string.wholeMatch(of: semVerRegex) else { return nil }
   |                                  `- error: value of type 'String' has no member 'wholeMatch'
26 |         guard
27 |             let major = Int(match.major),

root@orbstack:/host/SemanticVersion#
```

The fix is: https://forums.swift.org/t/webassembly-swift-sdk-selection-in-swift-6-2/82267/3

```
root@orbstack:/host/SemanticVersion# swift build --swift-sdk swift-6.3-RELEASE_wasm
Building for debugging...
[7/7] Emitting module SemanticVersion
Build complete! (4.25s)
root@orbstack:/host/SemanticVersion#
```