### PR TITLE
Move to organisation-wide policies

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,4 +1,0 @@
-# Thank you for your interest in supporting the Swift Package Index!
-# Learn more at https://github.com/sponsors/SwiftPackageIndex
-
-github: [SwiftPackageIndex]


### PR DESCRIPTION
Moved all policies to the `.github` repo so they are shared across the whole organisation.